### PR TITLE
Add noto fonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,8 @@ RUN         apk add --virtual .run-deps \
                 libva \
                 libvdpau \
                 vulkan-loader \
-                librsvg
+                librsvg \
+                font-noto
 
 COPY        --from=ffmpeg /usr/local/bin /usr/local/bin
 COPY        --from=ffmpeg /usr/local/lib /usr/local/lib


### PR DESCRIPTION
Rendering svg text blocks within ffmpeg needs fonts at runtime.
This PR adds the noto fonts that was used in our previous pipeline.